### PR TITLE
PSG-3741: ktlint github action

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[passage/generated/**/*]
+ktlint = disabled

--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -1,0 +1,16 @@
+name: ktlint
+on: [pull_request]
+jobs:
+  ktlint:
+    name: Check Code Quality with ktlint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: ktlint
+        uses: ScaCap/action-ktlint@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/passage/src/androidTest/java/id/passage/android/IntegrationTestConfig.kt
+++ b/passage/src/androidTest/java/id/passage/android/IntegrationTestConfig.kt
@@ -1,12 +1,10 @@
 package id.passage.android
 
 internal class IntegrationTestConfig {
-
     companion object {
         const val appId = "ADFxfSU7wg3loThFZ9cig3SG"
         const val apiBaseUrl = "https://auth-uat.passage.dev/v1"
         const val existingUserEmail = "authentigator+1684801767403@ncor7c1m.mailosaur.net"
         const val emailWaitTimeMilliseconds: Long = 5000
     }
-
 }

--- a/passage/src/androidTest/java/id/passage/android/MailosaurClient.kt
+++ b/passage/src/androidTest/java/id/passage/android/MailosaurClient.kt
@@ -1,9 +1,9 @@
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import java.util.Base64
 
 @Serializable
@@ -27,7 +27,7 @@ private data class ListMessage(
     val from: List<NameEmail>,
     val to: List<NameEmail>,
     val cc: List<String>,
-    val bcc: List<String>
+    val bcc: List<String>,
 )
 
 @Serializable
@@ -43,11 +43,10 @@ private data class GetMessageResponse(
     val to: List<NameEmail>,
     val cc: List<String>,
     val bcc: List<String>,
-    val html: MessageHTML
+    val html: MessageHTML,
 )
 
 internal object MailosaurAPIClient {
-
     internal const val serverId = "ncor7c1m"
 
     private const val apiURL = "https://mailosaur.com/api/messages"
@@ -69,10 +68,11 @@ internal object MailosaurAPIClient {
     private fun buildRequest(url: String): Request {
         return try {
             val parsedUrl = url.toHttpUrlOrNull() ?: throw Exception("Bad url path")
-            val request = Request.Builder()
-                .url(parsedUrl)
-                .addHeader("Authorization", authHeader)
-                .build()
+            val request =
+                Request.Builder()
+                    .url(parsedUrl)
+                    .addHeader("Authorization", authHeader)
+                    .build()
             request
         } catch (e: Exception) {
             throw Exception("Bad url path")
@@ -86,9 +86,10 @@ internal object MailosaurAPIClient {
             val message = getMessage(messages[0].id)
             val incomingURL = message.html.links[0].href
             val components = java.net.URL(incomingURL).query
-            val magicLink = components.split("&")
-                .find { it.startsWith("psg_magic_link=") }
-                ?.substringAfter("psg_magic_link=")
+            val magicLink =
+                components.split("&")
+                    .find { it.startsWith("psg_magic_link=") }
+                    ?.substringAfter("psg_magic_link=")
             magicLink ?: ""
         } catch (e: Exception) {
             ""

--- a/passage/src/androidTest/java/id/passage/android/OneTimePasscodeTests.kt
+++ b/passage/src/androidTest/java/id/passage/android/OneTimePasscodeTests.kt
@@ -22,7 +22,6 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 internal class OneTimePasscodeTests {
-
     private lateinit var passage: Passage
 
     @Before
@@ -36,87 +35,94 @@ internal class OneTimePasscodeTests {
     }
 
     @After
-    fun teardown() = runTest {
-        passage.signOutCurrentUser()
-    }
+    fun teardown() =
+        runTest {
+            passage.signOutCurrentUser()
+        }
 
     @get:Rule
-    var activityRule: ActivityScenarioRule<TestActivity?>? = ActivityScenarioRule(
-        TestActivity::class.java
-    )
+    var activityRule: ActivityScenarioRule<TestActivity?>? =
+        ActivityScenarioRule(
+            TestActivity::class.java,
+        )
 
     @Test
-    fun testRegisterOTPValid() = runTest {
-        val date = System.currentTimeMillis()
-        val identifier = "authentigator+$date@passage.id"
-        try {
-            passage.newRegisterOneTimePasscode(identifier)
-        } catch (e: Exception) {
-            fail("Test failed due to unexpected exception: ${e.message}")
-        }
-    }
-
-    @Test
-    fun testRegisterOTPNotValid() = runTest {
-        val identifier = "INVALID_IDENTIFIER"
-        try {
-            passage.newRegisterOneTimePasscode(identifier)
-            fail("Test should throw NewRegisterOneTimePasscodeInvalidIdentifierException")
-        } catch (e: Exception) {
-            assertThat(e is NewRegisterOneTimePasscodeInvalidIdentifierException)
-        }
-    }
-
-    @Test
-    fun testActivateRegisterOTPValid() = runTest {
-        runBlocking {
+    fun testRegisterOTPValid() =
+        runTest {
             val date = System.currentTimeMillis()
-            val identifier = "authentigator+$date@${MailosaurAPIClient.serverId}.mailosaur.net"
+            val identifier = "authentigator+$date@passage.id"
             try {
-                val otpId = passage.newRegisterOneTimePasscode(identifier).otpId
-                delay(emailWaitTimeMilliseconds)
-                val otp = MailosaurAPIClient.getMostRecentOneTimePasscode()
-                passage.oneTimePasscodeActivate(otp, otpId)
+                passage.newRegisterOneTimePasscode(identifier)
             } catch (e: Exception) {
                 fail("Test failed due to unexpected exception: ${e.message}")
             }
         }
-    }
 
     @Test
-    fun testLoginOTPValid() = runTest {
-        val identifier = existingUserEmail
-        try {
-            passage.newLoginOneTimePasscode(identifier)
-        } catch (e: Exception) {
-            fail("Test failed due to unexpected exception: ${e.message}")
-        }
-    }
-
-    @Test
-    fun testLoginOTPNotValid() = runTest {
-        val identifier = "INVALID_IDENTIFIER"
-        try {
-            passage.newLoginOneTimePasscode(identifier)
-            fail("Test should throw NewLoginOneTimePasscodeInvalidIdentifierException")
-        } catch (e: Exception) {
-            assertThat(e is NewLoginOneTimePasscodeInvalidIdentifierException)
-        }
-    }
-
-    @Test
-    fun testActivateLoginOTPValid() = runTest {
-        val identifier = existingUserEmail
-        runBlocking {
+    fun testRegisterOTPNotValid() =
+        runTest {
+            val identifier = "INVALID_IDENTIFIER"
             try {
-                val otpId = passage.newLoginOneTimePasscode(identifier).otpId
-                delay(emailWaitTimeMilliseconds)
-                val otp = MailosaurAPIClient.getMostRecentOneTimePasscode()
-                passage.oneTimePasscodeActivate(otp, otpId)
+                passage.newRegisterOneTimePasscode(identifier)
+                fail("Test should throw NewRegisterOneTimePasscodeInvalidIdentifierException")
+            } catch (e: Exception) {
+                assertThat(e is NewRegisterOneTimePasscodeInvalidIdentifierException)
+            }
+        }
+
+    @Test
+    fun testActivateRegisterOTPValid() =
+        runTest {
+            runBlocking {
+                val date = System.currentTimeMillis()
+                val identifier = "authentigator+$date@${MailosaurAPIClient.serverId}.mailosaur.net"
+                try {
+                    val otpId = passage.newRegisterOneTimePasscode(identifier).otpId
+                    delay(emailWaitTimeMilliseconds)
+                    val otp = MailosaurAPIClient.getMostRecentOneTimePasscode()
+                    passage.oneTimePasscodeActivate(otp, otpId)
+                } catch (e: Exception) {
+                    fail("Test failed due to unexpected exception: ${e.message}")
+                }
+            }
+        }
+
+    @Test
+    fun testLoginOTPValid() =
+        runTest {
+            val identifier = existingUserEmail
+            try {
+                passage.newLoginOneTimePasscode(identifier)
             } catch (e: Exception) {
                 fail("Test failed due to unexpected exception: ${e.message}")
             }
         }
-    }
 
+    @Test
+    fun testLoginOTPNotValid() =
+        runTest {
+            val identifier = "INVALID_IDENTIFIER"
+            try {
+                passage.newLoginOneTimePasscode(identifier)
+                fail("Test should throw NewLoginOneTimePasscodeInvalidIdentifierException")
+            } catch (e: Exception) {
+                assertThat(e is NewLoginOneTimePasscodeInvalidIdentifierException)
+            }
+        }
+
+    @Test
+    fun testActivateLoginOTPValid() =
+        runTest {
+            val identifier = existingUserEmail
+            runBlocking {
+                try {
+                    val otpId = passage.newLoginOneTimePasscode(identifier).otpId
+                    delay(emailWaitTimeMilliseconds)
+                    val otp = MailosaurAPIClient.getMostRecentOneTimePasscode()
+                    passage.oneTimePasscodeActivate(otp, otpId)
+                } catch (e: Exception) {
+                    fail("Test failed due to unexpected exception: ${e.message}")
+                }
+            }
+        }
 }

--- a/passage/src/androidTest/java/id/passage/android/SocialTests.kt
+++ b/passage/src/androidTest/java/id/passage/android/SocialTests.kt
@@ -2,19 +2,13 @@ package id.passage.android
 
 import android.content.Intent
 import androidx.browser.customtabs.CustomTabsIntent.SHARE_STATE_DEFAULT
-import androidx.test.ext.junit.rules.ActivityScenarioRule
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.test.runTest
-import org.junit.After
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.runner.RunWith
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasDataString
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.google.common.truth.Truth.assertThat
@@ -22,12 +16,17 @@ import id.passage.android.IntegrationTestConfig.Companion.apiBaseUrl
 import id.passage.android.IntegrationTestConfig.Companion.appId
 import id.passage.android.exceptions.FinishSocialAuthenticationInvalidRequestException
 import junit.framework.TestCase.fail
+import kotlinx.coroutines.test.runTest
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 internal class SocialTests {
-
     private lateinit var passage: Passage
 
     @Before
@@ -42,58 +41,63 @@ internal class SocialTests {
     }
 
     @After
-    fun teardown() = runTest {
-        Intents.release()
-    }
+    fun teardown() =
+        runTest {
+            Intents.release()
+        }
 
     @get:Rule
-    var activityRule: ActivityScenarioRule<TestActivity?>? = ActivityScenarioRule(
-        TestActivity::class.java
-    )
+    var activityRule: ActivityScenarioRule<TestActivity?>? =
+        ActivityScenarioRule(
+            TestActivity::class.java,
+        )
 
     @Test
-    fun testAuthorizeWith() = runTest {
-        try {
-            val expectedBasePath = "$apiBaseUrl/apps/${appId}/social/authorize"
-            val expectedRedirectUri = "redirect_uri=https%3A%2F%2Ftry-uat.passage.dev"
-            val expectedCodeChallengeMethod = "code_challenge_method=S256"
-            val expectedConnectionType = "connection_type=github"
-            val expectedState = "state="
-            val expectedCodeChallenge = "code_challenge="
+    fun testAuthorizeWith() =
+        runTest {
+            try {
+                val expectedBasePath = "$apiBaseUrl/apps/$appId/social/authorize"
+                val expectedRedirectUri = "redirect_uri=https%3A%2F%2Ftry-uat.passage.dev"
+                val expectedCodeChallengeMethod = "code_challenge_method=S256"
+                val expectedConnectionType = "connection_type=github"
+                val expectedState = "state="
+                val expectedCodeChallenge = "code_challenge="
 
-            passage.authorizeWith(PassageSocialConnection.github)
+                passage.authorizeWith(PassageSocialConnection.github)
 
-            intended(allOf(
-                // Web browser is open
-                hasAction(Intent.ACTION_VIEW),
-                // Web browser is a Custom Chrome Tab
-                hasExtra("androidx.browser.customtabs.extra.SHARE_STATE", SHARE_STATE_DEFAULT),
-                // Web browser url has expected base path
-                hasDataString(containsString(expectedBasePath)),
-                // Web browser url contains expected query params and values
-                hasDataString(containsString(expectedRedirectUri)),
-                hasDataString(containsString(expectedCodeChallengeMethod)),
-                hasDataString(containsString(expectedConnectionType)),
-                hasDataString(containsString(expectedState)),
-                hasDataString(containsString(expectedCodeChallenge)),
-            ))
-        } catch (e: Exception) {
-            fail("Test failed due to unexpected exception: ${e.message}")
-        } finally {
-            // Simulate a back press to dismiss the Custom Chrome Tab
-            UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).pressBack()
+                intended(
+                    allOf(
+                        // Web browser is open
+                        hasAction(Intent.ACTION_VIEW),
+                        // Web browser is a Custom Chrome Tab
+                        hasExtra("androidx.browser.customtabs.extra.SHARE_STATE", SHARE_STATE_DEFAULT),
+                        // Web browser url has expected base path
+                        hasDataString(containsString(expectedBasePath)),
+                        // Web browser url contains expected query params and values
+                        hasDataString(containsString(expectedRedirectUri)),
+                        hasDataString(containsString(expectedCodeChallengeMethod)),
+                        hasDataString(containsString(expectedConnectionType)),
+                        hasDataString(containsString(expectedState)),
+                        hasDataString(containsString(expectedCodeChallenge)),
+                    ),
+                )
+            } catch (e: Exception) {
+                fail("Test failed due to unexpected exception: ${e.message}")
+            } finally {
+                // Simulate a back press to dismiss the Custom Chrome Tab
+                UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).pressBack()
+            }
         }
-    }
 
     @Test
-    fun testFinishAuthorizationInvalidRequest() = runTest {
-        try {
-            val invalidAuthCode = "INVALID_AUTH_CODE"
-            passage.finishSocialAuthentication(invalidAuthCode)
-            fail("Test should throw FinishSocialAuthenticationInvalidRequestException")
-        } catch (e: Exception) {
-            assertThat(e is FinishSocialAuthenticationInvalidRequestException)
+    fun testFinishAuthorizationInvalidRequest() =
+        runTest {
+            try {
+                val invalidAuthCode = "INVALID_AUTH_CODE"
+                passage.finishSocialAuthentication(invalidAuthCode)
+                fail("Test should throw FinishSocialAuthenticationInvalidRequestException")
+            } catch (e: Exception) {
+                assertThat(e is FinishSocialAuthenticationInvalidRequestException)
+            }
         }
-    }
-
 }

--- a/passage/src/debug/java/id/passage/android/TestActivity.kt
+++ b/passage/src/debug/java/id/passage/android/TestActivity.kt
@@ -3,7 +3,7 @@ package id.passage.android
 import android.app.Activity
 import android.os.Bundle
 
-internal class TestActivity: Activity() {
+internal class TestActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_test)

--- a/passage/src/main/java/id/passage/android/PassageSocial.kt
+++ b/passage/src/main/java/id/passage/android/PassageSocial.kt
@@ -10,9 +10,7 @@ import java.security.SecureRandom
 import java.util.Base64
 
 internal class PassageSocial {
-
     internal companion object {
-
         internal var verifier = ""
         private const val CODE_CHALLENGE_METHOD = "S256"
         private const val SECRET_STRING_LENGTH = 32
@@ -21,23 +19,25 @@ internal class PassageSocial {
             connection: OAuth2ConnectionType,
             authOrigin: String,
             activity: Activity,
-            authUrl: String
+            authUrl: String,
         ) {
-            val redirectURI = "https://${authOrigin}"
+            val redirectURI = "https://$authOrigin"
             val state = getRandomString()
             val randomString = getRandomString()
             verifier = randomString
             val codeChallenge = sha256Hash(randomString)
-            val params = listOf(
-                "redirect_uri" to redirectURI,
-                "state" to state,
-                "code_challenge" to codeChallenge,
-                "code_challenge_method" to CODE_CHALLENGE_METHOD,
-                "connection_type" to connection.value
-            ).joinToString("&") {
-                (key, value) -> "$key=${URLEncoder.encode(value, "UTF-8")}"
-            }
-            val url = "${authUrl}?${params}"
+            val params =
+                listOf(
+                    "redirect_uri" to redirectURI,
+                    "state" to state,
+                    "code_challenge" to codeChallenge,
+                    "code_challenge_method" to CODE_CHALLENGE_METHOD,
+                    "connection_type" to connection.value,
+                ).joinToString("&") {
+                        (key, value) ->
+                    "$key=${URLEncoder.encode(value, "UTF-8")}"
+                }
+            val url = "$authUrl?$params"
             val intent = CustomTabsIntent.Builder().build()
             intent.launchUrl(activity, Uri.parse(url))
         }
@@ -46,8 +46,9 @@ internal class PassageSocial {
             val digits = '0'..'9'
             val upperCaseLetters = 'A'..'Z'
             val lowerCaseLetters = 'a'..'z'
-            val characters = (digits + upperCaseLetters + lowerCaseLetters)
-                .joinToString("")
+            val characters =
+                (digits + upperCaseLetters + lowerCaseLetters)
+                    .joinToString("")
             val random = SecureRandom()
             val stringBuilder = StringBuilder(SECRET_STRING_LENGTH)
             for (i in 0 until SECRET_STRING_LENGTH) {
@@ -63,7 +64,5 @@ internal class PassageSocial {
             val digest = md.digest(bytes)
             return Base64.getUrlEncoder().withoutPadding().encodeToString(digest)
         }
-
     }
-
 }

--- a/passage/src/main/java/id/passage/android/PassageToken.kt
+++ b/passage/src/main/java/id/passage/android/PassageToken.kt
@@ -13,7 +13,6 @@ private data class AuthTokenPayload(val exp: Long)
 
 @Suppress("unused", "RedundantVisibilityModifier")
 public object PassageToken {
-
     /**
      * Refresh Auth Token
      *
@@ -25,11 +24,12 @@ public object PassageToken {
     public suspend fun refreshAuthToken(refreshToken: String): PassageAuthResult {
         val api = TokensAPI(Passage.BASE_PATH)
         val request = RefreshAuthTokenRequest(refreshToken)
-        val apiAuthResult = try {
-            api.refreshAuthToken(Passage.appId, request).authResult
-        } catch (e: Exception) {
-            throw PassageTokenException.convert(e)
-        }
+        val apiAuthResult =
+            try {
+                api.refreshAuthToken(Passage.appId, request).authResult
+            } catch (e: Exception) {
+                throw PassageTokenException.convert(e)
+            }
         return apiAuthResult
     }
 
@@ -73,5 +73,4 @@ public object PassageToken {
             return false
         }
     }
-
 }

--- a/passage/src/main/java/id/passage/android/PassageTokenStore.kt
+++ b/passage/src/main/java/id/passage/android/PassageTokenStore.kt
@@ -12,27 +12,27 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.lang.Exception
 
-
 @Suppress("unused", "RedundantVisibilityModifier", "RedundantModalityModifier")
 public final class PassageTokenStore(activity: Activity) {
-
     private companion object {
         private const val PASSAGE_SHARED_PREFERENCES = "PASSAGE_SHARED_PREFERENCES"
         private const val PASSAGE_AUTH_TOKEN = "PASSAGE_AUTH_TOKEN"
         private const val PASSAGE_REFRESH_TOKEN = "PASSAGE_REFRESH_TOKEN"
     }
 
-    private val masterKey: MasterKey = MasterKey.Builder(activity)
-        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-        .build()
+    private val masterKey: MasterKey =
+        MasterKey.Builder(activity)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
 
-    private var sharedPreferences: SharedPreferences = EncryptedSharedPreferences.create(
-        activity,
-        PASSAGE_SHARED_PREFERENCES,
-        masterKey,
-        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-    )
+    private var sharedPreferences: SharedPreferences =
+        EncryptedSharedPreferences.create(
+            activity,
+            PASSAGE_SHARED_PREFERENCES,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
 
     public val authToken: String?
         get() = sharedPreferences.getString(PASSAGE_AUTH_TOKEN, null)
@@ -57,7 +57,7 @@ public final class PassageTokenStore(activity: Activity) {
     }
 
     private fun setAuthToken(token: String?) {
-        with (sharedPreferences.edit()) {
+        with(sharedPreferences.edit()) {
             putString(PASSAGE_AUTH_TOKEN, token)
             apply()
         }
@@ -66,7 +66,7 @@ public final class PassageTokenStore(activity: Activity) {
     }
 
     private fun setRefreshToken(token: String?) {
-        with (sharedPreferences.edit()) {
+        with(sharedPreferences.edit()) {
             putString(PASSAGE_REFRESH_TOKEN, token)
             apply()
         }
@@ -105,5 +105,4 @@ public final class PassageTokenStore(activity: Activity) {
             ApiClient.accessToken = authToken
         }
     }
-
 }

--- a/passage/src/main/java/id/passage/android/PassageUser.kt
+++ b/passage/src/main/java/id/passage/android/PassageUser.kt
@@ -15,52 +15,35 @@ import id.passage.android.model.WebAuthnType
 
 @Suppress("unused", "RedundantVisibilityModifier", "RedundantModalityModifier")
 final class PassageUser private constructor(
-
-    /* When this user was created */
+    // When this user was created
     val createdAt: String? = null,
-
-    /* The user's email */
+    // The user's email
     val email: String? = null,
-
-    /* Whether or not the user's email has been verified */
+    // Whether or not the user's email has been verified
     val emailVerified: Boolean? = null,
-
-    /* The userID (referred to as Handle) */
+    // The userID (referred to as Handle)
     val id: String? = null,
-
-    /* The last time this user logged in */
+    // The last time this user logged in
     val lastLoginAt: String? = null,
-
-    /* How many times the user has successfully logged in */
+    // How many times the user has successfully logged in
     val loginCount: Int? = null,
-
-    /* The user's phone */
+    // The user's phone
     val phone: String? = null,
-
-    /* Whether or not the user's phone has been verified */
+    // Whether or not the user's phone has been verified
     val phoneVerified: Boolean? = null,
-
-    /* User status: active, inactive, pending */
+    // User status: active, inactive, pending
     val status: String? = null,
-
-    /* When this user was last updated */
+    // When this user was last updated
     val updatedAt: String? = null,
-
     val userMetadata: Any? = null,
-
-    /* Whether or not the user has authenticated via webAuthn before (if len(WebAuthnDevices) > 0) */
+    // Whether or not the user has authenticated via webAuthn before (if len(WebAuthnDevices) > 0)
     val webauthn: Boolean? = null,
-
-    /* The list of devices this user has authenticated with via webAuthn */
+    // The list of devices this user has authenticated with via webAuthn
     val webauthnDevices: List<PassageCredential>? = null,
-
-    /* List of credential types that user has created */
-    val webauthnTypes: List<WebAuthnType>? = null
-
+    // List of credential types that user has created
+    val webauthnTypes: List<WebAuthnType>? = null,
 ) {
-
     internal companion object {
-
         /**
          * Get Current User
          *
@@ -72,11 +55,12 @@ final class PassageUser private constructor(
          */
         internal suspend fun getCurrentUser(): PassageUser? {
             val currentUserAPI = CurrentuserAPI(Passage.BASE_PATH)
-            val currentUser = try {
-                currentUserAPI.getCurrentuser(Passage.appId).user
-            } catch (e: Exception) {
-                throw PassageUserException.convert(e)
-            }
+            val currentUser =
+                try {
+                    currentUserAPI.getCurrentuser(Passage.appId).user
+                } catch (e: Exception) {
+                    throw PassageUserException.convert(e)
+                }
             return convertToPassageUser(currentUser)
         }
 
@@ -92,10 +76,10 @@ final class PassageUser private constructor(
                 phoneVerified = modelsCurrentUser.phoneVerified,
                 status = modelsCurrentUser.status,
                 updatedAt = modelsCurrentUser.updatedAt,
-                userMetadata= modelsCurrentUser.userMetadata,
+                userMetadata = modelsCurrentUser.userMetadata,
                 webauthn = modelsCurrentUser.webauthn,
                 webauthnDevices = modelsCurrentUser.webauthnDevices,
-                webauthnTypes = modelsCurrentUser.webauthnTypes
+                webauthnTypes = modelsCurrentUser.webauthnTypes,
             )
         }
 
@@ -107,9 +91,9 @@ final class PassageUser private constructor(
                 phone = modelsUser.phone,
                 phoneVerified = modelsUser.phoneVerified,
                 status = modelsUser.status,
-                userMetadata= modelsUser.userMetadata,
+                userMetadata = modelsUser.userMetadata,
                 webauthn = modelsUser.webauthn,
-                webauthnTypes = modelsUser.webauthnTypes
+                webauthnTypes = modelsUser.webauthnTypes,
             )
         }
     }
@@ -125,11 +109,12 @@ final class PassageUser private constructor(
     public suspend fun changeEmail(newEmail: String): MagicLink {
         val currentUserAPI = CurrentuserAPI(Passage.BASE_PATH)
         val request = UpdateUserEmailRequest(newEmail, Passage.language, null, null)
-        val response = try {
-            currentUserAPI.updateEmailCurrentuser(Passage.appId, request)
-        } catch (e: Exception) {
-            throw PassageUserException.convert(e)
-        }
+        val response =
+            try {
+                currentUserAPI.updateEmailCurrentuser(Passage.appId, request)
+            } catch (e: Exception) {
+                throw PassageUserException.convert(e)
+            }
         return response.magicLink
     }
 
@@ -144,11 +129,12 @@ final class PassageUser private constructor(
     public suspend fun changePhone(newPhone: String): MagicLink {
         val currentUserAPI = CurrentuserAPI(Passage.BASE_PATH)
         val request = UpdateUserPhoneRequest(Passage.language, null, newPhone, null)
-        val response = try {
-            currentUserAPI.updatePhoneCurrentuser(Passage.appId, request)
-        } catch (e: Exception) {
-            throw PassageUserException.convert(e)
-        }
+        val response =
+            try {
+                currentUserAPI.updatePhoneCurrentuser(Passage.appId, request)
+            } catch (e: Exception) {
+                throw PassageUserException.convert(e)
+            }
         return response.magicLink
     }
 
@@ -178,7 +164,10 @@ final class PassageUser private constructor(
      * @return PassageCredential
      * @throws PassageUserException
      */
-    public suspend fun editDevicePasskeyName(deviceId: String, newDevicePasskeyName: String): PassageCredential {
+    public suspend fun editDevicePasskeyName(
+        deviceId: String,
+        newDevicePasskeyName: String,
+    ): PassageCredential {
         val currentUserAPI = CurrentuserAPI(Passage.BASE_PATH)
         val request = UpdateDeviceRequest(friendlyName = newDevicePasskeyName)
         return try {
@@ -206,11 +195,12 @@ final class PassageUser private constructor(
             val createCredResponse = PasskeyUtils.createPasskey(createCredOptionsJson, activity)
             // Complete registration
             val handshakeResponse = PasskeyUtils.getCreateCredentialHandshakeResponse(createCredResponse)
-            val finishRequest = AddDeviceFinishRequest(
-                handshakeId = webauthnStartResponse.handshake.id,
-                handshakeResponse = handshakeResponse,
-                userId = webauthnStartResponse.user?.id ?: ""
-            )
+            val finishRequest =
+                AddDeviceFinishRequest(
+                    handshakeId = webauthnStartResponse.handshake.id,
+                    handshakeResponse = handshakeResponse,
+                    userId = webauthnStartResponse.user?.id ?: "",
+                )
             return currentUserAPI.postCurrentuserAddDeviceFinish(Passage.appId, finishRequest).device
         } catch (e: Exception) {
             throw AddDevicePasskeyException.convert(e)
@@ -233,5 +223,4 @@ final class PassageUser private constructor(
             PassageUserException.convert(e)
         }
     }
-
 }

--- a/passage/src/main/java/id/passage/android/ResourceUtils.kt
+++ b/passage/src/main/java/id/passage/android/ResourceUtils.kt
@@ -4,26 +4,28 @@ import android.app.Activity
 
 @Suppress("unused", "RedundantModalityModifier")
 internal final class ResourceUtils {
-
     internal companion object {
-
-        internal fun getOptionalResourceFromApp(activity: Activity, resName: String): String? {
+        internal fun getOptionalResourceFromApp(
+            activity: Activity,
+            resName: String,
+        ): String? {
             val stringRes = activity.resources.getIdentifier(resName, "string", activity.packageName)
             if (stringRes == 0) return null
             return activity.getString(stringRes)
         }
 
-        internal fun getRequiredResourceFromApp(activity: Activity, resName: String): String {
+        internal fun getRequiredResourceFromApp(
+            activity: Activity,
+            resName: String,
+        ): String {
             val stringRes = getOptionalResourceFromApp(activity, resName)
             require(!stringRes.isNullOrBlank()) {
                 String.format(
                     "The 'R.string.%s' value it's not defined in your project's resources file.",
-                    resName
+                    resName,
                 )
             }
             return stringRes
         }
-
     }
-
 }

--- a/passage/src/main/java/id/passage/android/exceptions/AddDevicePasskeyException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/AddDevicePasskeyException.kt
@@ -22,10 +22,8 @@ import id.passage.client.infrastructure.ServerException
  * @see AddDevicePasskeyInactiveUserException
  * @see AddDevicePasskeyServerException
  */
-public open class AddDevicePasskeyException(message: String): PassageException(message) {
-
+public open class AddDevicePasskeyException(message: String) : PassageException(message) {
     internal companion object {
-
         internal fun convert(e: Exception): AddDevicePasskeyException {
             val message = e.message ?: e.toString()
             return when (e) {
@@ -68,44 +66,41 @@ public open class AddDevicePasskeyException(message: String): PassageException(m
                 else -> AddDevicePasskeyException(message)
             }
         }
-
     }
-
 }
-
 
 /**
  * The user intentionally canceled the operation and chose not to create the credential.
  */
-public class AddDevicePasskeyCancellationException(message: String): AddDevicePasskeyException(message)
+public class AddDevicePasskeyCancellationException(message: String) : AddDevicePasskeyException(message)
 
 /**
  * Credential creation was interrupted. Consider retrying the call.
  */
-public class AddDevicePasskeyInterruptedException(message: String): AddDevicePasskeyException(message)
+public class AddDevicePasskeyInterruptedException(message: String) : AddDevicePasskeyException(message)
 
 /**
  * Your app is missing the provider configuration dependency.
  * Most likely, your app has not been properly configured for Passage.
  */
-public class AddDevicePasskeyConfigurationException(message: String): AddDevicePasskeyException(message)
+public class AddDevicePasskeyConfigurationException(message: String) : AddDevicePasskeyException(message)
 
 /**
  * Thrown because of a bad request, typically when an invalid identifier is provided.
  */
-public class AddDevicePasskeyInvalidRequestException(message: String): AddDevicePasskeyException(message)
+public class AddDevicePasskeyInvalidRequestException(message: String) : AddDevicePasskeyException(message)
 
 /**
  * Thrown when the request is not authorized, typically when the token has expired or not been set.
  */
-public class AddDevicePasskeyUnauthorizedException(message: String): AddDevicePasskeyException(message)
+public class AddDevicePasskeyUnauthorizedException(message: String) : AddDevicePasskeyException(message)
 
 /**
  * Thrown when the user is not active.
  */
-public class AddDevicePasskeyInactiveUserException(message: String): AddDevicePasskeyException(message)
+public class AddDevicePasskeyInactiveUserException(message: String) : AddDevicePasskeyException(message)
 
 /**
  * Thrown when Passage internal server error occurs.
  */
-public class AddDevicePasskeyServerException(message: String): AddDevicePasskeyException(message)
+public class AddDevicePasskeyServerException(message: String) : AddDevicePasskeyException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/AppInfoException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/AppInfoException.kt
@@ -12,8 +12,7 @@ import id.passage.client.infrastructure.ServerException
  * @see AppInfoNotFoundException
  * @see AppInfoServerException
  */
-public open class AppInfoException(message: String): PassageException(message) {
-
+public open class AppInfoException(message: String) : PassageException(message) {
     internal companion object {
         internal fun convert(e: Exception): AppInfoException {
             val message = e.message ?: e.toString()
@@ -37,15 +36,14 @@ public open class AppInfoException(message: String): PassageException(message) {
             }
         }
     }
-
 }
 
 /**
  * Thrown when no Passage app is found with the provided app id.
  */
-public class AppInfoNotFoundException(message: String): AppInfoException(message)
+public class AppInfoNotFoundException(message: String) : AppInfoException(message)
 
 /**
  * Thrown when Passage internal server error occurs.
  */
-public class AppInfoServerException(message: String): AppInfoException(message)
+public class AppInfoServerException(message: String) : AppInfoException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/CredentialParsingException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/CredentialParsingException.kt
@@ -5,7 +5,7 @@ package id.passage.android.exceptions
 /**
  * Thrown when parsing of WebAuthn credentials fails.
  */
-public open class CredentialParsingException(message: String): PassageException(message) {
+public open class CredentialParsingException(message: String) : PassageException(message) {
     internal companion object {
         const val CHALLENGE_MISSING = "WebAuthn credential assertion challenge missing."
         const val CHALLENGE_PARSING_FAILED = "WebAuthn credential assertion challenge parsing failed."

--- a/passage/src/main/java/id/passage/android/exceptions/FinishSocialAuthenticationException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/FinishSocialAuthenticationException.kt
@@ -14,10 +14,8 @@ import id.passage.client.infrastructure.ServerException
  * @see FinishSocialAuthenticationNotVerifiedException
  * @see FinishSocialAuthenticationServerException
  */
-public open class FinishSocialAuthenticationException(message: String):
-    PassageException(message)
-{
-
+public open class FinishSocialAuthenticationException(message: String) :
+    PassageException(message) {
     internal companion object {
         internal fun convert(e: Exception): FinishSocialAuthenticationException {
             val message = e.message ?: e.toString()
@@ -28,9 +26,7 @@ public open class FinishSocialAuthenticationException(message: String):
             }
         }
 
-        private fun convertClientException(e: ClientException):
-            FinishSocialAuthenticationException
-        {
+        private fun convertClientException(e: ClientException): FinishSocialAuthenticationException {
             val error = parseClientException(e)
             val message = error?.error ?: ""
             return when (error?.code) {
@@ -46,24 +42,22 @@ public open class FinishSocialAuthenticationException(message: String):
             }
         }
     }
-
 }
-
 
 /**
  * Thrown when the auth code is invalid.
  */
-public class FinishSocialAuthenticationInvalidRequestException(message: String):
+public class FinishSocialAuthenticationInvalidRequestException(message: String) :
     FinishSocialAuthenticationException(message)
 
 /**
  * Thrown when the user's identifier has not been verified.
  */
-public class FinishSocialAuthenticationNotVerifiedException(message: String):
+public class FinishSocialAuthenticationNotVerifiedException(message: String) :
     FinishSocialAuthenticationException(message)
 
 /**
  * Thrown when Passage internal server error occurs.
  */
-public class FinishSocialAuthenticationServerException(message: String):
+public class FinishSocialAuthenticationServerException(message: String) :
     FinishSocialAuthenticationException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/GetMagicLinkStatusException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/GetMagicLinkStatusException.kt
@@ -14,10 +14,8 @@ import id.passage.client.infrastructure.ServerException
  * @see GetMagicLinkStatusNotFoundException
  * @see GetMagicLinkStatusServerException
  */
-public open class GetMagicLinkStatusException(message: String): PassageException(message) {
-
+public open class GetMagicLinkStatusException(message: String) : PassageException(message) {
     internal companion object {
-
         internal fun convert(e: Exception): GetMagicLinkStatusException {
             val message = e.message ?: e.toString()
             return when (e) {
@@ -42,22 +40,20 @@ public open class GetMagicLinkStatusException(message: String): PassageException
                 }
             }
         }
-
     }
-
 }
 
 /**
  * Thrown when provided magic link id is invalid.
  */
-public class GetMagicLinkStatusInvalidException(message: String): GetMagicLinkStatusException(message)
+public class GetMagicLinkStatusInvalidException(message: String) : GetMagicLinkStatusException(message)
 
 /**
  * Thrown when provided magic link id is not found.
  */
-public class GetMagicLinkStatusNotFoundException(message: String): GetMagicLinkStatusException(message)
+public class GetMagicLinkStatusNotFoundException(message: String) : GetMagicLinkStatusException(message)
 
 /**
  * Thrown when Passage internal server error occurs.
  */
-public class GetMagicLinkStatusServerException(message: String): GetMagicLinkStatusException(message)
+public class GetMagicLinkStatusServerException(message: String) : GetMagicLinkStatusException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/LoginException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/LoginException.kt
@@ -9,20 +9,20 @@ package id.passage.android.exceptions
  * @see LoginNoExistingUserException
  * @see LoginNoFallbackException
  */
-public open class LoginException(message: String): PassageException(message)
+public open class LoginException(message: String) : PassageException(message)
 
 /**
  * Thrown when there's an issue with the Passage app, typically indicating "passage_app_id" has not
  * been set in your strings.xml file.
  */
-public class LoginInvalidAppException(message: String = "Invalid Passage app."): LoginException(message)
+public class LoginInvalidAppException(message: String = "Invalid Passage app.") : LoginException(message)
 
 /**
  * Thrown when login attempt failed because no user exists with provided identifier.
  */
-public class LoginNoExistingUserException(message: String = "User with this identifier does not exist."): LoginException(message)
+public class LoginNoExistingUserException(message: String = "User with this identifier does not exist.") : LoginException(message)
 
 /**
  * Thrown when attempting to use a fallback login method but none has been set in Passage app.
  */
-public class LoginNoFallbackException(message: String = "Passage app has no fallback set."): LoginException(message)
+public class LoginNoFallbackException(message: String = "Passage app has no fallback set.") : LoginException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/LoginWithPasskeyException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/LoginWithPasskeyException.kt
@@ -23,10 +23,8 @@ import id.passage.client.infrastructure.ServerException
  * @see LoginWithPasskeyCredentialException
  * @see LoginWithPasskeyServerException
  */
-public open class LoginWithPasskeyException(message: String): PassageException(message) {
-
+public open class LoginWithPasskeyException(message: String) : PassageException(message) {
     internal companion object {
-
         internal fun convert(e: Exception): LoginWithPasskeyException {
             val message = e.message ?: e.toString()
             return when (e) {
@@ -80,60 +78,58 @@ public open class LoginWithPasskeyException(message: String): PassageException(m
                 else -> LoginWithPasskeyException(message)
             }
         }
-
     }
-
 }
 
 /**
  * The user intentionally canceled the operation and chose not to register the credential.
  */
-public class LoginWithPasskeyCancellationException(message: String): LoginWithPasskeyException(message)
+public class LoginWithPasskeyCancellationException(message: String) : LoginWithPasskeyException(message)
 
 /**
  * Credential creation was interrupted. Consider retrying the call.
  */
-public class LoginWithPasskeyInterruptedException(message: String): LoginWithPasskeyException(message)
+public class LoginWithPasskeyInterruptedException(message: String) : LoginWithPasskeyException(message)
 
 /**
  * Your app is missing the provider configuration dependency.
  * Most likely, your app has not been properly configured for Passage.
  */
-public class LoginWithPasskeyConfigurationException(message: String): LoginWithPasskeyException(message)
+public class LoginWithPasskeyConfigurationException(message: String) : LoginWithPasskeyException(message)
 
 /**
  * During the get credential flow, this is thrown when credential manager is unsupported, typically
  * because the device has disabled it or did not ship with this feature enabled.
  */
-public class LoginWithPasskeyUnsupportedException(message: String): LoginWithPasskeyException(message)
+public class LoginWithPasskeyUnsupportedException(message: String) : LoginWithPasskeyException(message)
 
 /**
  * During the get credential flow, this is returned when no viable credential is available for the
  * the user.
  */
-public class LoginWithPasskeyNoCredentialException(message: String): LoginWithPasskeyException(message)
+public class LoginWithPasskeyNoCredentialException(message: String) : LoginWithPasskeyException(message)
 
 /**
  * Thrown because of a bad request, typically when an invalid identifier is provided.
  */
-public class LoginWithPasskeyInvalidRequestException(message: String): LoginWithPasskeyException(message)
+public class LoginWithPasskeyInvalidRequestException(message: String) : LoginWithPasskeyException(message)
 
 /**
  * Thrown when no identifier is provided and login fails.
  */
-public class LoginWithPasskeyDiscoverableLoginException(message: String): LoginWithPasskeyException(message)
+public class LoginWithPasskeyDiscoverableLoginException(message: String) : LoginWithPasskeyException(message)
 
 /**
  * Thrown when the user is not active.
  */
-public class LoginWithPasskeyInactiveUserException(message: String): LoginWithPasskeyException(message)
+public class LoginWithPasskeyInactiveUserException(message: String) : LoginWithPasskeyException(message)
 
 /**
  * Thrown because of an issue with the passkey credential.
  */
-public class LoginWithPasskeyCredentialException(message: String): LoginWithPasskeyException(message)
+public class LoginWithPasskeyCredentialException(message: String) : LoginWithPasskeyException(message)
 
 /**
  * Thrown when Passage internal server error occurs.
  */
-public class LoginWithPasskeyServerException(message: String): LoginWithPasskeyException(message)
+public class LoginWithPasskeyServerException(message: String) : LoginWithPasskeyException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/MagicLinkActivateException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/MagicLinkActivateException.kt
@@ -14,10 +14,8 @@ import id.passage.client.infrastructure.ServerException
  * @see MagicLinkActivateUserNotActiveException
  * @see MagicLinkActivateServerException
  */
-public open class MagicLinkActivateException(message: String): PassageException(message) {
-
+public open class MagicLinkActivateException(message: String) : PassageException(message) {
     internal companion object {
-
         internal fun convert(e: Exception): MagicLinkActivateException {
             val message = e.message ?: e.toString()
             return when (e) {
@@ -42,22 +40,20 @@ public open class MagicLinkActivateException(message: String): PassageException(
                 }
             }
         }
-
     }
-
 }
 
 /**
  * Thrown when the magic link is invalid
  */
-public class MagicLinkActivateInvalidException(message: String): MagicLinkActivateException(message)
+public class MagicLinkActivateInvalidException(message: String) : MagicLinkActivateException(message)
 
 /**
  * Thrown when the user is not active.
  */
-public class MagicLinkActivateUserNotActiveException(message: String): MagicLinkActivateException(message)
+public class MagicLinkActivateUserNotActiveException(message: String) : MagicLinkActivateException(message)
 
 /**
  * Thrown when Passage internal server error occurs.
  */
-public class MagicLinkActivateServerException(message: String): MagicLinkActivateException(message)
+public class MagicLinkActivateServerException(message: String) : MagicLinkActivateException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/NewLoginMagicLinkException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/NewLoginMagicLinkException.kt
@@ -12,15 +12,13 @@ import id.passage.client.infrastructure.ServerException
  * @see NewLoginMagicLinkInvalidIdentifierException
  * @see NewLoginMagicLinkServerException
  */
-public open class NewLoginMagicLinkException(message: String): PassageException(message) {
-
+public open class NewLoginMagicLinkException(message: String) : PassageException(message) {
     internal companion object {
-
         internal fun convert(e: Exception): NewLoginMagicLinkException {
             val message = e.message ?: e.toString()
             return when (e) {
                 is ClientException -> convertClientException(e)
-                is ServerException ->NewLoginMagicLinkServerException(message)
+                is ServerException -> NewLoginMagicLinkServerException(message)
                 else -> NewLoginMagicLinkException(message)
             }
         }
@@ -33,17 +31,15 @@ public open class NewLoginMagicLinkException(message: String): PassageException(
                 else -> NewLoginMagicLinkException(message)
             }
         }
-
     }
-
 }
 
 /**
  * Thrown when the provided identifier is invalid.
  */
-public class NewLoginMagicLinkInvalidIdentifierException(message: String): NewLoginMagicLinkException(message)
+public class NewLoginMagicLinkInvalidIdentifierException(message: String) : NewLoginMagicLinkException(message)
 
 /**
  * Thrown when Passage internal server error occurs.
  */
-public class NewLoginMagicLinkServerException(message: String): NewLoginMagicLinkException(message)
+public class NewLoginMagicLinkServerException(message: String) : NewLoginMagicLinkException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/NewLoginOneTimePasscodeException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/NewLoginOneTimePasscodeException.kt
@@ -12,10 +12,8 @@ import id.passage.client.infrastructure.ServerException
  * @see NewLoginOneTimePasscodeInvalidIdentifierException
  * @see NewLoginOneTimePasscodeServerException
  */
-public open class NewLoginOneTimePasscodeException(message: String): PassageException(message) {
-
+public open class NewLoginOneTimePasscodeException(message: String) : PassageException(message) {
     internal companion object {
-
         internal fun convert(e: Exception): NewLoginOneTimePasscodeException {
             val message = e.message ?: e.toString()
             return when (e) {
@@ -33,17 +31,15 @@ public open class NewLoginOneTimePasscodeException(message: String): PassageExce
                 else -> NewLoginOneTimePasscodeException(message)
             }
         }
-
     }
-
 }
 
 /**
  * Thrown when the provided identifier is invalid.
  */
-public class NewLoginOneTimePasscodeInvalidIdentifierException(message: String): NewLoginOneTimePasscodeException(message)
+public class NewLoginOneTimePasscodeInvalidIdentifierException(message: String) : NewLoginOneTimePasscodeException(message)
 
 /**
  * Thrown when Passage internal server error occurs.
  */
-public class NewLoginOneTimePasscodeServerException(message: String): NewLoginOneTimePasscodeException(message)
+public class NewLoginOneTimePasscodeServerException(message: String) : NewLoginOneTimePasscodeException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/NewRegisterMagicLinkExtension.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/NewRegisterMagicLinkExtension.kt
@@ -12,10 +12,8 @@ import id.passage.client.infrastructure.ServerException
  * @see NewRegisterMagicLinkInvalidIdentifierException
  * @see NewRegisterMagicLinkServerException
  */
-public open class NewRegisterMagicLinkException(message: String): PassageException(message) {
-
+public open class NewRegisterMagicLinkException(message: String) : PassageException(message) {
     internal companion object {
-
         internal fun convert(e: Exception): NewRegisterMagicLinkException {
             val message = e.message ?: e.toString()
             return when (e) {
@@ -33,17 +31,15 @@ public open class NewRegisterMagicLinkException(message: String): PassageExcepti
                 else -> NewRegisterMagicLinkException(message)
             }
         }
-
     }
-
 }
 
 /**
  * Thrown when the provided identifier is invalid.
  */
-public class NewRegisterMagicLinkInvalidIdentifierException(message: String): NewRegisterMagicLinkException(message)
+public class NewRegisterMagicLinkInvalidIdentifierException(message: String) : NewRegisterMagicLinkException(message)
 
 /**
  * Thrown when Passage internal server error occurs.
  */
-public class NewRegisterMagicLinkServerException(message: String): NewRegisterMagicLinkException(message)
+public class NewRegisterMagicLinkServerException(message: String) : NewRegisterMagicLinkException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/NewRegisterOneTimePasscodeException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/NewRegisterOneTimePasscodeException.kt
@@ -12,10 +12,8 @@ import id.passage.client.infrastructure.ServerException
  * @see NewRegisterOneTimePasscodeInvalidIdentifierException
  * @see NewRegisterOneTimePasscodeServerException
  */
-public open class NewRegisterOneTimePasscodeException(message: String): PassageException(message) {
-
+public open class NewRegisterOneTimePasscodeException(message: String) : PassageException(message) {
     internal companion object {
-
         internal fun convert(e: Exception): NewRegisterOneTimePasscodeException {
             val message = e.message ?: e.toString()
             return when (e) {
@@ -33,17 +31,15 @@ public open class NewRegisterOneTimePasscodeException(message: String): PassageE
                 else -> NewRegisterOneTimePasscodeException(message)
             }
         }
-
     }
-
 }
 
 /**
  * Thrown when the provided identifier is invalid.
  */
-public class NewRegisterOneTimePasscodeInvalidIdentifierException(message: String): NewRegisterOneTimePasscodeException(message)
+public class NewRegisterOneTimePasscodeInvalidIdentifierException(message: String) : NewRegisterOneTimePasscodeException(message)
 
 /**
  * Thrown when Passage internal server error occurs.
  */
-public class NewRegisterOneTimePasscodeServerException(message: String): NewRegisterOneTimePasscodeException(message)
+public class NewRegisterOneTimePasscodeServerException(message: String) : NewRegisterOneTimePasscodeException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/OneTimePasscodeActivateException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/OneTimePasscodeActivateException.kt
@@ -16,10 +16,8 @@ import id.passage.client.infrastructure.ServerException
  * @see OneTimePasscodeActivateExceededAttemptsException
  * @see OneTimePasscodeActivateServerException
  */
-public open class OneTimePasscodeActivateException(message: String): PassageException(message) {
-
+public open class OneTimePasscodeActivateException(message: String) : PassageException(message) {
     internal companion object {
-
         internal fun convert(e: Exception): OneTimePasscodeActivateException {
             val message = e.message ?: e.toString()
             return when (e) {
@@ -47,27 +45,25 @@ public open class OneTimePasscodeActivateException(message: String): PassageExce
                 }
             }
         }
-
     }
-
 }
 
 /**
  * Thrown when either the otp or the otpId is invalid.
  */
-public class OneTimePasscodeActivateInvalidRequestException(message: String): OneTimePasscodeActivateException(message)
+public class OneTimePasscodeActivateInvalidRequestException(message: String) : OneTimePasscodeActivateException(message)
 
 /**
  * Thrown when the user is not active.
  */
-public class OneTimePasscodeActivateInactiveUserException(message: String): OneTimePasscodeActivateException(message)
+public class OneTimePasscodeActivateInactiveUserException(message: String) : OneTimePasscodeActivateException(message)
 
 /**
  * Thrown when the user has had too many failed activation attempts.
  */
-public class OneTimePasscodeActivateExceededAttemptsException(message: String): OneTimePasscodeActivateException(message)
+public class OneTimePasscodeActivateExceededAttemptsException(message: String) : OneTimePasscodeActivateException(message)
 
 /**
  * Thrown when Passage internal server error occurs.
  */
-public class OneTimePasscodeActivateServerException(message: String): OneTimePasscodeActivateException(message)
+public class OneTimePasscodeActivateServerException(message: String) : OneTimePasscodeActivateException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/PassageException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/PassageException.kt
@@ -8,9 +8,8 @@ import com.squareup.moshi.adapter
 import id.passage.client.infrastructure.ClientError
 import id.passage.client.infrastructure.ClientException
 
-public open class PassageException(message: String): RuntimeException(message) {
+public open class PassageException(message: String) : RuntimeException(message) {
     companion object {
-
         @OptIn(ExperimentalStdlibApi::class)
         fun parseClientException(e: ClientException): PassageClientError? {
             val errorBody = (e.response as? ClientError<*>)?.body?.toString() ?: return null
@@ -19,9 +18,7 @@ public open class PassageException(message: String): RuntimeException(message) {
             val jsonAdapter = moshi.adapter<PassageClientError?>().lenient() ?: return null
             return jsonAdapter.fromJson(errorBody)
         }
-
     }
-
 }
 
 @JsonClass(generateAdapter = true)

--- a/passage/src/main/java/id/passage/android/exceptions/PassageTokenException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/PassageTokenException.kt
@@ -11,10 +11,8 @@ import id.passage.client.infrastructure.ServerException
  * @see PassageTokenUnauthorizedException
  * @see PassageTokenServerException
  */
-public open class PassageTokenException(message: String): PassageException(message) {
-
+public open class PassageTokenException(message: String) : PassageException(message) {
     internal companion object {
-
         internal fun convert(e: Exception): PassageTokenException {
             val message = e.message ?: e.toString()
             return when (e) {
@@ -31,17 +29,15 @@ public open class PassageTokenException(message: String): PassageException(messa
                 else -> PassageTokenException(message)
             }
         }
-
     }
-
 }
 
 /**
  * Thrown when the request is not authorized, typically when the token has expired or not been set.
  */
-public class PassageTokenUnauthorizedException(message: String): PassageTokenException(message)
+public class PassageTokenUnauthorizedException(message: String) : PassageTokenException(message)
 
 /**
  * Thrown when Passage internal server error occurs.
  */
-public class PassageTokenServerException(message: String): PassageTokenException(message)
+public class PassageTokenServerException(message: String) : PassageTokenException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/PassageUserException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/PassageUserException.kt
@@ -17,10 +17,8 @@ import id.passage.client.infrastructure.ServerException
  * @see PassageUserInactiveUserException
  * @see PassageUserServerException
  */
-public open class PassageUserException(message: String): PassageException(message) {
-
+public open class PassageUserException(message: String) : PassageException(message) {
     internal companion object {
-
         internal fun convert(e: Exception): PassageUserException {
             val message = e.message ?: e.toString()
             return when (e) {
@@ -49,32 +47,30 @@ public open class PassageUserException(message: String): PassageException(messag
             }
             return PassageUserException(message)
         }
-
     }
-
 }
 
 /**
  * Thrown when invalid values are provided to the request.
  */
-public class PassageUserRequestException(message: String): PassageUserException(message)
+public class PassageUserRequestException(message: String) : PassageUserException(message)
 
 /**
  * Thrown when the request is not authorized, typically when the token has expired or not been set.
  */
-public class PassageUserUnauthorizedException(message: String): PassageUserException(message)
+public class PassageUserUnauthorizedException(message: String) : PassageUserException(message)
 
 /**
  * Thrown when the user is not found.
  */
-public class PassageUserNotFoundException(message: String): PassageUserException(message)
+public class PassageUserNotFoundException(message: String) : PassageUserException(message)
 
 /**
  * Thrown when the user is not active.
  */
-public class PassageUserInactiveUserException(message: String): PassageUserException(message)
+public class PassageUserInactiveUserException(message: String) : PassageUserException(message)
 
 /**
  * Thrown when Passage internal server error occurs.
  */
-public class PassageUserServerException(message: String): PassageUserException(message)
+public class PassageUserServerException(message: String) : PassageUserException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/RegisterException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/RegisterException.kt
@@ -10,25 +10,25 @@ package id.passage.android.exceptions
  * @see RegisterPublicDisabledException
  * @see RegisterNoFallbackException
  */
-public open class RegisterException(message: String): PassageException(message)
+public open class RegisterException(message: String) : PassageException(message)
 
 /**
  * Thrown when a user with provided identifier already exists.
  */
-public class RegisterUserExistsException(message: String = "User already exists."): RegisterException(message)
+public class RegisterUserExistsException(message: String = "User already exists.") : RegisterException(message)
 
 /**
  * Thrown when there's an issue with the Passage app, typically indicating "passage_app_id" has not
  * been set in your strings.xml file.
  */
-public class RegisterInvalidAppException(message: String = "Invalid Passage app."): RegisterException(message)
+public class RegisterInvalidAppException(message: String = "Invalid Passage app.") : RegisterException(message)
 
 /**
  * Thrown when your Passage app has "public_signup" set to false.
  */
-public class RegisterPublicDisabledException(message: String = "Public registration disabled for this app."): RegisterException(message)
+public class RegisterPublicDisabledException(message: String = "Public registration disabled for this app.") : RegisterException(message)
 
 /**
  * Thrown when attempting to use a fallback registration method but none has been set in Passage app.
  */
-public class RegisterNoFallbackException(message: String = "Passage app has no fallback set."): RegisterException(message)
+public class RegisterNoFallbackException(message: String = "Passage app has no fallback set.") : RegisterException(message)

--- a/passage/src/main/java/id/passage/android/exceptions/RegisterWithPasskeyException.kt
+++ b/passage/src/main/java/id/passage/android/exceptions/RegisterWithPasskeyException.kt
@@ -20,10 +20,8 @@ import id.passage.client.infrastructure.ServerException
  * @see RegisterWithPasskeyCredentialException
  * @see RegisterWithPasskeyServerException
  */
-public open class RegisterWithPasskeyException(message: String): PassageException(message) {
-
+public open class RegisterWithPasskeyException(message: String) : PassageException(message) {
     internal companion object {
-
         internal fun convert(e: Exception): RegisterWithPasskeyException {
             val message = e.message ?: e.toString()
             return when (e) {
@@ -71,50 +69,48 @@ public open class RegisterWithPasskeyException(message: String): PassageExceptio
                 else -> RegisterWithPasskeyException(message)
             }
         }
-
     }
-
 }
 
 /**
  * The user intentionally canceled the operation and chose not to register the credential.
  */
-public class RegisterWithPasskeyCancellationException(message: String): RegisterWithPasskeyException(message)
+public class RegisterWithPasskeyCancellationException(message: String) : RegisterWithPasskeyException(message)
 
 /**
  * Credential creation was interrupted. Consider retrying the call.
  */
-public class RegisterWithPasskeyInterruptedException(message: String): RegisterWithPasskeyException(message)
+public class RegisterWithPasskeyInterruptedException(message: String) : RegisterWithPasskeyException(message)
 
 /**
  * Your app is missing the provider configuration dependency.
  * Most likely, your app has not been properly configured for Passage.
  */
-public class RegisterWithPasskeyConfigurationException(message: String): RegisterWithPasskeyException(message)
+public class RegisterWithPasskeyConfigurationException(message: String) : RegisterWithPasskeyException(message)
 
 /**
  * During the create credential flow, this is thrown when no viable creation options were found for
  * the given CreateCredentialRequest.
  */
-public class RegisterWithPasskeyNoCreateOptionException(message: String): RegisterWithPasskeyException(message)
+public class RegisterWithPasskeyNoCreateOptionException(message: String) : RegisterWithPasskeyException(message)
 
 /**
  * During the create credential flow, this is thrown when credential manager is unsupported,
  * typically because the device has disabled it or did not ship with this feature enabled.
  */
-public class RegisterWithPasskeyUnsupportedException(message: String): RegisterWithPasskeyException(message)
+public class RegisterWithPasskeyUnsupportedException(message: String) : RegisterWithPasskeyException(message)
 
 /**
  * Thrown because of a bad request, typically when an invalid identifier is provided.
  */
-public class RegisterWithPasskeyInvalidRequestException(message: String): RegisterWithPasskeyException(message)
+public class RegisterWithPasskeyInvalidRequestException(message: String) : RegisterWithPasskeyException(message)
 
 /**
  * Thrown because of an issue with the passkey credential.
  */
-public class RegisterWithPasskeyCredentialException(message: String): RegisterWithPasskeyException(message)
+public class RegisterWithPasskeyCredentialException(message: String) : RegisterWithPasskeyException(message)
 
 /**
  * Thrown when Passage internal server error occurs.
  */
-public class RegisterWithPasskeyServerException(message: String): RegisterWithPasskeyException(message)
+public class RegisterWithPasskeyServerException(message: String) : RegisterWithPasskeyException(message)

--- a/passage/src/test/java/id/passage/android/ExampleUnitTest.kt
+++ b/passage/src/test/java/id/passage/android/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package id.passage.android
 
-import org.junit.Test
-
 import org.junit.Assert.*
+import org.junit.Test
 
 /**
  * Example local unit test, which will execute on the development machine (host).


### PR DESCRIPTION
### Overview of Changes in this PR

-   run ktlint workflow on PR
-   ignore generated code
-   run `ktlint --format`

An example of the generated output can be seen in [this run](https://github.com/passageidentity/passage-android/actions/runs/8282224267/job/22662579722).

### Links


* [ktlint](https://pinterest.github.io/ktlint/latest/)
* [action-ktlint inputs](https://github.com/ScaCap/action-ktlint?tab=readme-ov-file#inputs)
The notable inputs that could be useful are `level` & `filter_mode`.
* [How do I disable ktlint for generated code?](https://pinterest.github.io/ktlint/latest/faq/#how-do-i-disable-ktlint-for-generated-code)
This is used to ignore codegen files.
* [How do I suppress errors for a line/block/file?](https://pinterest.github.io/ktlint/latest/faq/#how-do-i-suppress-errors-for-a-lineblockfile)
