### PR TITLE
PSG-3983

### DIFF
--- a/passage/src/androidTest/java/id/passage/android/IntegrationTestConfig.kt
+++ b/passage/src/androidTest/java/id/passage/android/IntegrationTestConfig.kt
@@ -3,8 +3,11 @@ package id.passage.android
 internal class IntegrationTestConfig {
     companion object {
         const val API_BASE_URL = "https://auth-uat.passage.dev/v1"
-        const val APP_ID = "ADFxfSU7wg3loThFZ9cig3SG"
-        const val EMAIL_WAIT_TIME_MILLISECONDS: Long = 8000
-        const val EXISTING_USER_EMAIL = "authentigator+1684801767403@ncor7c1m.mailosaur.net"
+        const val APP_ID_OTP = "Ezbk6fSdx9pNQ7v7UbVEnzeC"
+        const val APP_ID_MAGIC_LINK = "Pea2GdtBHN3esylK4ZRlF19U"
+        const val WAIT_TIME_MILLISECONDS: Long = 8000
+        const val EXISTING_USER_EMAIL_OTP = "authentigator+1684801767403@ncor7c1m.mailosaur.net"
+        const val EXISTING_USER_EMAIL_MAGIC_LINK = "authentigator+1716572384858@ncor7c1m.mailosaur.net"
+        const val DEACTIVATED_USER_EMAIL_MAGIC_LINK = "authentigator+1716778790434@ncor7c1m.mailosaur.net"
     }
 }

--- a/passage/src/androidTest/java/id/passage/android/IntegrationTestConfig.kt
+++ b/passage/src/androidTest/java/id/passage/android/IntegrationTestConfig.kt
@@ -6,7 +6,7 @@ internal class IntegrationTestConfig {
         const val APP_ID_OTP = "Ezbk6fSdx9pNQ7v7UbVEnzeC"
         const val APP_ID_MAGIC_LINK = "Pea2GdtBHN3esylK4ZRlF19U"
         const val WAIT_TIME_MILLISECONDS: Long = 8000
-        const val EXISTING_USER_EMAIL_OTP = "authentigator+1684801767403@ncor7c1m.mailosaur.net"
+        const val EXISTING_USER_EMAIL_OTP = "authentigator+1716916054778@ncor7c1m.mailosaur.net"
         const val EXISTING_USER_EMAIL_MAGIC_LINK = "authentigator+1716572384858@ncor7c1m.mailosaur.net"
         const val DEACTIVATED_USER_EMAIL_MAGIC_LINK = "authentigator+1716778790434@ncor7c1m.mailosaur.net"
     }

--- a/passage/src/androidTest/java/id/passage/android/MagicLinkTests.kt
+++ b/passage/src/androidTest/java/id/passage/android/MagicLinkTests.kt
@@ -60,7 +60,7 @@ internal class MagicLinkTests {
     }
 
     @Test
-    fun testRegisterExcitingUserMagicLink() = runTest {
+    fun testRegisterExistingUserMagicLink() = runTest {
         try {
             passage.newRegisterMagicLink(EXISTING_USER_EMAIL_MAGIC_LINK, null)
             fail("Test should throw NewRegisterMagicLinkInvalidIdentifierException")

--- a/passage/src/androidTest/java/id/passage/android/MagicLinkTests.kt
+++ b/passage/src/androidTest/java/id/passage/android/MagicLinkTests.kt
@@ -1,0 +1,168 @@
+package id.passage.android
+
+import MailosaurAPIClient
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import junit.framework.TestCase.fail
+import kotlinx.coroutines.test.runTest
+import id.passage.android.IntegrationTestConfig.Companion.API_BASE_URL
+import id.passage.android.IntegrationTestConfig.Companion.APP_ID_MAGIC_LINK
+import id.passage.android.IntegrationTestConfig.Companion.DEACTIVATED_USER_EMAIL_MAGIC_LINK
+import id.passage.android.IntegrationTestConfig.Companion.EXISTING_USER_EMAIL_MAGIC_LINK
+import id.passage.android.exceptions.MagicLinkActivateInvalidException
+import id.passage.android.exceptions.MagicLinkActivateUserNotActiveException
+import id.passage.android.exceptions.NewLoginMagicLinkInvalidIdentifierException
+import id.passage.android.exceptions.NewRegisterMagicLinkInvalidIdentifierException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class MagicLinkTests {
+    private lateinit var passage: Passage
+
+    @Before
+    fun setUp() {
+        activityRule?.scenario?.onActivity { activity ->
+            activity?.let {
+                passage = Passage(it, APP_ID_MAGIC_LINK)
+                passage.overrideBasePath(API_BASE_URL)
+            }
+        }
+    }
+
+    @get:Rule
+    var activityRule: ActivityScenarioRule<TestActivity?>? = ActivityScenarioRule(
+        TestActivity::class.java,
+    )
+
+    @After
+    fun tearDown() {
+        runTest {
+            passage.signOutCurrentUser()
+        }
+    }
+
+    @Test
+    fun testSendRegisterMagicLink() = runTest {
+        try {
+            val date = System.currentTimeMillis()
+            val identifier = "authentigator+$date@passage.id"
+            passage.newRegisterMagicLink(identifier, null)
+        } catch (e: Exception) {
+            fail(e.message)
+        }
+    }
+
+    @Test
+    fun testRegisterExcitingUserMagicLink() = runTest {
+        try {
+            passage.newRegisterMagicLink(EXISTING_USER_EMAIL_MAGIC_LINK, null)
+            fail("Test should throw NewRegisterMagicLinkInvalidIdentifierException")
+        } catch (e: Exception) {
+            assertThat(e is NewRegisterMagicLinkInvalidIdentifierException)
+        }
+    }
+
+    @Test
+    fun testRegisterInvalidEmailAddressFormatMagicLink() = runTest {
+        try {
+            passage.newRegisterMagicLink("invalid", null)
+            fail("Test should throw NewRegisterMagicLinkInvalidIdentifierException")
+        } catch (e: Exception) {
+            assertThat(e is NewRegisterMagicLinkInvalidIdentifierException)
+        }
+    }
+
+    @Test
+    fun testSendLoginMagicLink() = runTest {
+        try {
+            val identifier = EXISTING_USER_EMAIL_MAGIC_LINK
+            passage.newLoginMagicLink(identifier, null)
+        } catch (e: Exception) {
+            fail(e.message)
+        }
+    }
+
+    @Test
+    fun testInvalidLoginMagicLink() = runTest {
+        try {
+            passage.newLoginMagicLink("Invalid@invalid.com", null)
+            fail("Test should throw NewLoginMagicLinkInvalidIdentifierException")
+        } catch (e: Exception) {
+            assertThat(e is NewLoginMagicLinkInvalidIdentifierException)
+        }
+    }
+
+
+    @Test
+    fun testActivateRegisterMagicLink(): Unit = runBlocking {
+        try {
+            val date = System.currentTimeMillis()
+            val identifier = "authentigator+$date@${MailosaurAPIClient.serverId}.mailosaur.net"
+            passage.newRegisterMagicLink(identifier, null)
+            delay(IntegrationTestConfig.WAIT_TIME_MILLISECONDS)
+            val magicLink: String = MailosaurAPIClient.getMostRecentMagicLink()
+            if (magicLink == "") {
+                fail("Test Failed: Magic link is empty")
+            }
+            passage.magicLinkActivate(magicLink)
+        } catch (e: Exception) {
+            fail(e.toString())
+        }
+    }
+
+    @Test
+    fun testActivateLoginMagicLink(): Unit = runBlocking {
+        try {
+            passage.newLoginMagicLink(EXISTING_USER_EMAIL_MAGIC_LINK, null)
+            delay(IntegrationTestConfig.WAIT_TIME_MILLISECONDS)
+            val magicLink: String = MailosaurAPIClient.getMostRecentMagicLink()
+            if (magicLink.isEmpty()) {
+                fail("Test failed: Mailosaur function returned an empty magic link")
+            }
+            passage.magicLinkActivate(magicLink)
+        } catch (e: Exception) {
+            fail(e.toString())
+        }
+    }
+
+
+    @Test
+    fun testActivateInvalidMagicLink() = runTest {
+        runBlocking {
+            try {
+                val date = System.currentTimeMillis()
+                val identifier = "authentigator+$date@${MailosaurAPIClient.serverId}.mailosaur.net"
+                passage.newRegisterMagicLink(identifier, null)
+                val magicLink = "Invalid"
+                passage.magicLinkActivate(magicLink)
+                fail("Test failed: Mailosaur function returned an empty magic link")
+            } catch (e: Exception) {
+                assertThat(e is MagicLinkActivateInvalidException)
+            }
+        }
+    }
+
+    @Test
+    fun testActivateDeactivatedUserMagicLink() = runTest {
+        try {
+            passage.newLoginMagicLink(DEACTIVATED_USER_EMAIL_MAGIC_LINK, null)
+            delay(IntegrationTestConfig.WAIT_TIME_MILLISECONDS)
+            val magicLink: String = MailosaurAPIClient.getMostRecentMagicLink()
+            if (magicLink.isEmpty()) {
+                fail("Mailosaur catched error; returning empty string")
+            }
+            passage.magicLinkActivate(magicLink)
+            fail("Test should throw MagicLinkActivateUserNotActiveException")
+        } catch (e: Exception) {
+            assertThat(e is MagicLinkActivateUserNotActiveException)
+        }
+    }
+
+}

--- a/passage/src/androidTest/java/id/passage/android/MagicLinkTests.kt
+++ b/passage/src/androidTest/java/id/passage/android/MagicLinkTests.kt
@@ -4,8 +4,6 @@ import MailosaurAPIClient
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
-import junit.framework.TestCase.fail
-import kotlinx.coroutines.test.runTest
 import id.passage.android.IntegrationTestConfig.Companion.API_BASE_URL
 import id.passage.android.IntegrationTestConfig.Companion.APP_ID_MAGIC_LINK
 import id.passage.android.IntegrationTestConfig.Companion.DEACTIVATED_USER_EMAIL_MAGIC_LINK
@@ -14,8 +12,10 @@ import id.passage.android.exceptions.MagicLinkActivateInvalidException
 import id.passage.android.exceptions.MagicLinkActivateUserNotActiveException
 import id.passage.android.exceptions.NewLoginMagicLinkInvalidIdentifierException
 import id.passage.android.exceptions.NewRegisterMagicLinkInvalidIdentifierException
+import junit.framework.TestCase.fail
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -37,9 +37,10 @@ internal class MagicLinkTests {
     }
 
     @get:Rule
-    var activityRule: ActivityScenarioRule<TestActivity?>? = ActivityScenarioRule(
-        TestActivity::class.java,
-    )
+    var activityRule: ActivityScenarioRule<TestActivity?>? =
+        ActivityScenarioRule(
+            TestActivity::class.java,
+        )
 
     @After
     fun tearDown() {
@@ -49,120 +50,126 @@ internal class MagicLinkTests {
     }
 
     @Test
-    fun testSendRegisterMagicLink() = runTest {
-        try {
-            val date = System.currentTimeMillis()
-            val identifier = "authentigator+$date@passage.id"
-            passage.newRegisterMagicLink(identifier, null)
-        } catch (e: Exception) {
-            fail(e.message)
-        }
-    }
-
-    @Test
-    fun testRegisterExistingUserMagicLink() = runTest {
-        try {
-            passage.newRegisterMagicLink(EXISTING_USER_EMAIL_MAGIC_LINK, null)
-            fail("Test should throw NewRegisterMagicLinkInvalidIdentifierException")
-        } catch (e: Exception) {
-            assertThat(e is NewRegisterMagicLinkInvalidIdentifierException)
-        }
-    }
-
-    @Test
-    fun testRegisterInvalidEmailAddressFormatMagicLink() = runTest {
-        try {
-            passage.newRegisterMagicLink("invalid", null)
-            fail("Test should throw NewRegisterMagicLinkInvalidIdentifierException")
-        } catch (e: Exception) {
-            assertThat(e is NewRegisterMagicLinkInvalidIdentifierException)
-        }
-    }
-
-    @Test
-    fun testSendLoginMagicLink() = runTest {
-        try {
-            val identifier = EXISTING_USER_EMAIL_MAGIC_LINK
-            passage.newLoginMagicLink(identifier, null)
-        } catch (e: Exception) {
-            fail(e.message)
-        }
-    }
-
-    @Test
-    fun testInvalidLoginMagicLink() = runTest {
-        try {
-            passage.newLoginMagicLink("Invalid@invalid.com", null)
-            fail("Test should throw NewLoginMagicLinkInvalidIdentifierException")
-        } catch (e: Exception) {
-            assertThat(e is NewLoginMagicLinkInvalidIdentifierException)
-        }
-    }
-
-
-    @Test
-    fun testActivateRegisterMagicLink(): Unit = runBlocking {
-        try {
-            val date = System.currentTimeMillis()
-            val identifier = "authentigator+$date@${MailosaurAPIClient.serverId}.mailosaur.net"
-            passage.newRegisterMagicLink(identifier, null)
-            delay(IntegrationTestConfig.WAIT_TIME_MILLISECONDS)
-            val magicLink: String = MailosaurAPIClient.getMostRecentMagicLink()
-            if (magicLink == "") {
-                fail("Test Failed: Magic link is empty")
+    fun testSendRegisterMagicLink() =
+        runTest {
+            try {
+                val date = System.currentTimeMillis()
+                val identifier = "authentigator+$date@passage.id"
+                passage.newRegisterMagicLink(identifier, null)
+            } catch (e: Exception) {
+                fail(e.message)
             }
-            passage.magicLinkActivate(magicLink)
-        } catch (e: Exception) {
-            fail(e.toString())
         }
-    }
 
     @Test
-    fun testActivateLoginMagicLink(): Unit = runBlocking {
-        try {
-            passage.newLoginMagicLink(EXISTING_USER_EMAIL_MAGIC_LINK, null)
-            delay(IntegrationTestConfig.WAIT_TIME_MILLISECONDS)
-            val magicLink: String = MailosaurAPIClient.getMostRecentMagicLink()
-            if (magicLink.isEmpty()) {
-                fail("Test failed: Mailosaur function returned an empty magic link")
+    fun testRegisterExistingUserMagicLink() =
+        runTest {
+            try {
+                passage.newRegisterMagicLink(EXISTING_USER_EMAIL_MAGIC_LINK, null)
+                fail("Test should throw NewRegisterMagicLinkInvalidIdentifierException")
+            } catch (e: Exception) {
+                assertThat(e is NewRegisterMagicLinkInvalidIdentifierException)
             }
-            passage.magicLinkActivate(magicLink)
-        } catch (e: Exception) {
-            fail(e.toString())
         }
-    }
-
 
     @Test
-    fun testActivateInvalidMagicLink() = runTest {
+    fun testRegisterInvalidEmailAddressFormatMagicLink() =
+        runTest {
+            try {
+                passage.newRegisterMagicLink("invalid", null)
+                fail("Test should throw NewRegisterMagicLinkInvalidIdentifierException")
+            } catch (e: Exception) {
+                assertThat(e is NewRegisterMagicLinkInvalidIdentifierException)
+            }
+        }
+
+    @Test
+    fun testSendLoginMagicLink() =
+        runTest {
+            try {
+                val identifier = EXISTING_USER_EMAIL_MAGIC_LINK
+                passage.newLoginMagicLink(identifier, null)
+            } catch (e: Exception) {
+                fail(e.message)
+            }
+        }
+
+    @Test
+    fun testInvalidLoginMagicLink() =
+        runTest {
+            try {
+                passage.newLoginMagicLink("Invalid@invalid.com", null)
+                fail("Test should throw NewLoginMagicLinkInvalidIdentifierException")
+            } catch (e: Exception) {
+                assertThat(e is NewLoginMagicLinkInvalidIdentifierException)
+            }
+        }
+
+    @Test
+    fun testActivateRegisterMagicLink(): Unit =
         runBlocking {
             try {
                 val date = System.currentTimeMillis()
                 val identifier = "authentigator+$date@${MailosaurAPIClient.serverId}.mailosaur.net"
                 passage.newRegisterMagicLink(identifier, null)
-                val magicLink = "Invalid"
+                delay(IntegrationTestConfig.WAIT_TIME_MILLISECONDS)
+                val magicLink: String = MailosaurAPIClient.getMostRecentMagicLink()
+                if (magicLink == "") {
+                    fail("Test Failed: Magic link is empty")
+                }
                 passage.magicLinkActivate(magicLink)
-                fail("Test failed: Mailosaur function returned an empty magic link")
             } catch (e: Exception) {
-                assertThat(e is MagicLinkActivateInvalidException)
+                fail(e.toString())
             }
         }
-    }
 
     @Test
-    fun testActivateDeactivatedUserMagicLink() = runTest {
-        try {
-            passage.newLoginMagicLink(DEACTIVATED_USER_EMAIL_MAGIC_LINK, null)
-            delay(IntegrationTestConfig.WAIT_TIME_MILLISECONDS)
-            val magicLink: String = MailosaurAPIClient.getMostRecentMagicLink()
-            if (magicLink.isEmpty()) {
-                fail("Mailosaur catched error; returning empty string")
+    fun testActivateLoginMagicLink(): Unit =
+        runBlocking {
+            try {
+                passage.newLoginMagicLink(EXISTING_USER_EMAIL_MAGIC_LINK, null)
+                delay(IntegrationTestConfig.WAIT_TIME_MILLISECONDS)
+                val magicLink: String = MailosaurAPIClient.getMostRecentMagicLink()
+                if (magicLink.isEmpty()) {
+                    fail("Test failed: Mailosaur function returned an empty magic link")
+                }
+                passage.magicLinkActivate(magicLink)
+            } catch (e: Exception) {
+                fail(e.toString())
             }
-            passage.magicLinkActivate(magicLink)
-            fail("Test should throw MagicLinkActivateUserNotActiveException")
-        } catch (e: Exception) {
-            assertThat(e is MagicLinkActivateUserNotActiveException)
         }
-    }
 
+    @Test
+    fun testActivateInvalidMagicLink() =
+        runTest {
+            runBlocking {
+                try {
+                    val date = System.currentTimeMillis()
+                    val identifier = "authentigator+$date@${MailosaurAPIClient.serverId}.mailosaur.net"
+                    passage.newRegisterMagicLink(identifier, null)
+                    val magicLink = "Invalid"
+                    passage.magicLinkActivate(magicLink)
+                    fail("Test failed: Mailosaur function returned an empty magic link")
+                } catch (e: Exception) {
+                    assertThat(e is MagicLinkActivateInvalidException)
+                }
+            }
+        }
+
+    @Test
+    fun testActivateDeactivatedUserMagicLink() =
+        runTest {
+            try {
+                passage.newLoginMagicLink(DEACTIVATED_USER_EMAIL_MAGIC_LINK, null)
+                delay(IntegrationTestConfig.WAIT_TIME_MILLISECONDS)
+                val magicLink: String = MailosaurAPIClient.getMostRecentMagicLink()
+                if (magicLink.isEmpty()) {
+                    fail("Mailosaur catched error; returning empty string")
+                }
+                passage.magicLinkActivate(magicLink)
+                fail("Test should throw MagicLinkActivateUserNotActiveException")
+            } catch (e: Exception) {
+                assertThat(e is MagicLinkActivateUserNotActiveException)
+            }
+        }
 }

--- a/passage/src/androidTest/java/id/passage/android/OneTimePasscodeTests.kt
+++ b/passage/src/androidTest/java/id/passage/android/OneTimePasscodeTests.kt
@@ -5,9 +5,9 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import id.passage.android.IntegrationTestConfig.Companion.API_BASE_URL
-import id.passage.android.IntegrationTestConfig.Companion.APP_ID
-import id.passage.android.IntegrationTestConfig.Companion.EMAIL_WAIT_TIME_MILLISECONDS
-import id.passage.android.IntegrationTestConfig.Companion.EXISTING_USER_EMAIL
+import id.passage.android.IntegrationTestConfig.Companion.APP_ID_OTP
+import id.passage.android.IntegrationTestConfig.Companion.WAIT_TIME_MILLISECONDS
+import id.passage.android.IntegrationTestConfig.Companion.EXISTING_USER_EMAIL_OTP
 import id.passage.android.exceptions.NewLoginOneTimePasscodeInvalidIdentifierException
 import id.passage.android.exceptions.NewRegisterOneTimePasscodeInvalidIdentifierException
 import junit.framework.TestCase.fail
@@ -28,7 +28,7 @@ internal class OneTimePasscodeTests {
     fun setup() {
         activityRule?.scenario?.onActivity { activity ->
             activity?.let {
-                passage = Passage(it, APP_ID)
+                passage = Passage(it, APP_ID_OTP)
                 passage.overrideBasePath(API_BASE_URL)
             }
         }
@@ -78,7 +78,7 @@ internal class OneTimePasscodeTests {
                 val identifier = "authentigator+$date@${MailosaurAPIClient.serverId}.mailosaur.net"
                 try {
                     val otpId = passage.newRegisterOneTimePasscode(identifier).otpId
-                    delay(EMAIL_WAIT_TIME_MILLISECONDS)
+                    delay(WAIT_TIME_MILLISECONDS)
                     val otp = MailosaurAPIClient.getMostRecentOneTimePasscode()
                     passage.oneTimePasscodeActivate(otp, otpId)
                 } catch (e: Exception) {
@@ -90,7 +90,7 @@ internal class OneTimePasscodeTests {
     @Test
     fun testLoginOTPValid() =
         runTest {
-            val identifier = EXISTING_USER_EMAIL
+            val identifier = EXISTING_USER_EMAIL_OTP
             try {
                 passage.newLoginOneTimePasscode(identifier)
             } catch (e: Exception) {
@@ -113,11 +113,11 @@ internal class OneTimePasscodeTests {
     @Test
     fun testActivateLoginOTPValid() =
         runTest {
-            val identifier = EXISTING_USER_EMAIL
+            val identifier = EXISTING_USER_EMAIL_OTP
             runBlocking {
                 try {
                     val otpId = passage.newLoginOneTimePasscode(identifier).otpId
-                    delay(EMAIL_WAIT_TIME_MILLISECONDS)
+                    delay(WAIT_TIME_MILLISECONDS)
                     val otp = MailosaurAPIClient.getMostRecentOneTimePasscode()
                     passage.oneTimePasscodeActivate(otp, otpId)
                 } catch (e: Exception) {

--- a/passage/src/androidTest/java/id/passage/android/OneTimePasscodeTests.kt
+++ b/passage/src/androidTest/java/id/passage/android/OneTimePasscodeTests.kt
@@ -6,8 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import id.passage.android.IntegrationTestConfig.Companion.API_BASE_URL
 import id.passage.android.IntegrationTestConfig.Companion.APP_ID_OTP
-import id.passage.android.IntegrationTestConfig.Companion.WAIT_TIME_MILLISECONDS
 import id.passage.android.IntegrationTestConfig.Companion.EXISTING_USER_EMAIL_OTP
+import id.passage.android.IntegrationTestConfig.Companion.WAIT_TIME_MILLISECONDS
 import id.passage.android.exceptions.NewLoginOneTimePasscodeInvalidIdentifierException
 import id.passage.android.exceptions.NewRegisterOneTimePasscodeInvalidIdentifierException
 import junit.framework.TestCase.fail
@@ -71,19 +71,17 @@ internal class OneTimePasscodeTests {
         }
 
     @Test
-    fun testActivateRegisterOTPValid() =
-        runTest {
-            runBlocking {
-                val date = System.currentTimeMillis()
-                val identifier = "authentigator+$date@${MailosaurAPIClient.serverId}.mailosaur.net"
-                try {
-                    val otpId = passage.newRegisterOneTimePasscode(identifier).otpId
-                    delay(WAIT_TIME_MILLISECONDS)
-                    val otp = MailosaurAPIClient.getMostRecentOneTimePasscode()
-                    passage.oneTimePasscodeActivate(otp, otpId)
-                } catch (e: Exception) {
-                    fail("Test failed due to unexpected exception: ${e.message}")
-                }
+    fun testActivateRegisterOTPValid(): Unit =
+        runBlocking {
+            val date = System.currentTimeMillis()
+            val identifier = "authentigator+$date@${MailosaurAPIClient.serverId}.mailosaur.net"
+            try {
+                val otpId = passage.newRegisterOneTimePasscode(identifier).otpId
+                delay(WAIT_TIME_MILLISECONDS)
+                val otp = MailosaurAPIClient.getMostRecentOneTimePasscode()
+                passage.oneTimePasscodeActivate(otp, otpId)
+            } catch (e: Exception) {
+                fail("Test failed due to unexpected exception: ${e.message}")
             }
         }
 
@@ -111,18 +109,16 @@ internal class OneTimePasscodeTests {
         }
 
     @Test
-    fun testActivateLoginOTPValid() =
-        runTest {
+    fun testActivateLoginOTPValid(): Unit =
+        runBlocking {
             val identifier = EXISTING_USER_EMAIL_OTP
-            runBlocking {
-                try {
-                    val otpId = passage.newLoginOneTimePasscode(identifier).otpId
-                    delay(WAIT_TIME_MILLISECONDS)
-                    val otp = MailosaurAPIClient.getMostRecentOneTimePasscode()
-                    passage.oneTimePasscodeActivate(otp, otpId)
-                } catch (e: Exception) {
-                    fail("Test failed due to unexpected exception: ${e.message}")
-                }
+            try {
+                val otpId = passage.newLoginOneTimePasscode(identifier).otpId
+                delay(WAIT_TIME_MILLISECONDS)
+                val otp = MailosaurAPIClient.getMostRecentOneTimePasscode()
+                passage.oneTimePasscodeActivate(otp, otpId)
+            } catch (e: Exception) {
+                fail("Test failed due to unexpected exception: ${e.message}")
             }
         }
 }

--- a/passage/src/androidTest/java/id/passage/android/SocialTests.kt
+++ b/passage/src/androidTest/java/id/passage/android/SocialTests.kt
@@ -13,7 +13,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.google.common.truth.Truth.assertThat
 import id.passage.android.IntegrationTestConfig.Companion.API_BASE_URL
-import id.passage.android.IntegrationTestConfig.Companion.APP_ID
+import id.passage.android.IntegrationTestConfig.Companion.APP_ID_OTP
 import id.passage.android.exceptions.FinishSocialAuthenticationInvalidRequestException
 import junit.framework.TestCase.fail
 import kotlinx.coroutines.test.runTest
@@ -34,7 +34,7 @@ internal class SocialTests {
         Intents.init()
         activityRule?.scenario?.onActivity { activity ->
             activity?.let {
-                passage = Passage(it, APP_ID)
+                passage = Passage(it, APP_ID_OTP)
                 passage.overrideBasePath(API_BASE_URL)
             }
         }
@@ -56,7 +56,7 @@ internal class SocialTests {
     fun testAuthorizeWith() =
         runTest {
             try {
-                val expectedBasePath = "$API_BASE_URL/apps/$APP_ID/social/authorize"
+                val expectedBasePath = "$API_BASE_URL/apps/$APP_ID_OTP/social/authorize"
                 val expectedRedirectUri = "redirect_uri=https%3A%2F%2Ftry-uat.passage.dev"
                 val expectedCodeChallengeMethod = "code_challenge_method=S256"
                 val expectedConnectionType = "connection_type=github"

--- a/passage/src/androidTest/java/id/passage/android/TokenStoreTests.kt
+++ b/passage/src/androidTest/java/id/passage/android/TokenStoreTests.kt
@@ -5,9 +5,9 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import id.passage.android.IntegrationTestConfig.Companion.API_BASE_URL
-import id.passage.android.IntegrationTestConfig.Companion.APP_ID
-import id.passage.android.IntegrationTestConfig.Companion.EMAIL_WAIT_TIME_MILLISECONDS
-import id.passage.android.IntegrationTestConfig.Companion.EXISTING_USER_EMAIL
+import id.passage.android.IntegrationTestConfig.Companion.APP_ID_OTP
+import id.passage.android.IntegrationTestConfig.Companion.WAIT_TIME_MILLISECONDS
+import id.passage.android.IntegrationTestConfig.Companion.EXISTING_USER_EMAIL_OTP
 import id.passage.android.exceptions.PassageUserUnauthorizedException
 import junit.framework.TestCase.fail
 import kotlinx.coroutines.delay
@@ -28,13 +28,13 @@ internal class TokenStoreTests {
         runBlocking {
             activityRule?.scenario?.onActivity { activity ->
                 activity?.let {
-                    passage = Passage(it, APP_ID)
+                    passage = Passage(it, APP_ID_OTP)
                     passage.overrideBasePath(API_BASE_URL)
                 }
             }
             // Log in user
-            val otpId = passage.newLoginOneTimePasscode(EXISTING_USER_EMAIL).otpId
-            delay(EMAIL_WAIT_TIME_MILLISECONDS)
+            val otpId = passage.newLoginOneTimePasscode(EXISTING_USER_EMAIL_OTP).otpId
+            delay(WAIT_TIME_MILLISECONDS)
             val otp = MailosaurAPIClient.getMostRecentOneTimePasscode()
             passage.oneTimePasscodeActivate(otp, otpId)
         }

--- a/passage/src/androidTest/java/id/passage/android/TokenStoreTests.kt
+++ b/passage/src/androidTest/java/id/passage/android/TokenStoreTests.kt
@@ -6,8 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import id.passage.android.IntegrationTestConfig.Companion.API_BASE_URL
 import id.passage.android.IntegrationTestConfig.Companion.APP_ID_OTP
-import id.passage.android.IntegrationTestConfig.Companion.WAIT_TIME_MILLISECONDS
 import id.passage.android.IntegrationTestConfig.Companion.EXISTING_USER_EMAIL_OTP
+import id.passage.android.IntegrationTestConfig.Companion.WAIT_TIME_MILLISECONDS
 import id.passage.android.exceptions.PassageUserUnauthorizedException
 import junit.framework.TestCase.fail
 import kotlinx.coroutines.delay


### PR DESCRIPTION
- Added seven different tests for magic link functionality.
- Updated `IntegrationTestConfig.kt` to support both OTP and magic link tests with various App IDs and email addresses.