### PR TITLE
Upgraded hosted auth to PKCE

### DIFF
--- a/passage/build.gradle
+++ b/passage/build.gradle
@@ -27,7 +27,7 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    
+
     buildFeatures {
         buildConfig = true
     }
@@ -93,9 +93,9 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:4.10.0"
 
     // For JSON serialization and parsing
-    implementation "com.squareup.moshi:moshi:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.14.0"
+    implementation "com.squareup.moshi:moshi:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.15.1"
 
 
     // For safely encrypting stored data

--- a/passage/src/androidTest/java/id/passage/android/HostedTests.kt
+++ b/passage/src/androidTest/java/id/passage/android/HostedTests.kt
@@ -86,7 +86,7 @@ internal class HostedTests {
         runTest {
             try {
                 val invalidAuthCode = "INVALID_AUTH_CODE"
-                passage.hostedAuthFinish(invalidAuthCode, "", "")
+                passage.hostedAuthFinish(invalidAuthCode, "")
                 fail("Test should throw FinishOIDCAuthenticationInvalidRequestException")
             } catch (e: Exception) {
                 assertThat(e is HostedAuthorizationError)

--- a/passage/src/main/java/id/passage/android/Passage.kt
+++ b/passage/src/main/java/id/passage/android/Passage.kt
@@ -12,7 +12,28 @@ import id.passage.android.api.OAuth2API
 import id.passage.android.api.OTPAPI
 import id.passage.android.api.RegisterAPI
 import id.passage.android.api.UsersAPI
-import id.passage.android.exceptions.*
+import id.passage.android.exceptions.AppInfoException
+import id.passage.android.exceptions.FinishSocialAuthenticationException
+import id.passage.android.exceptions.GetMagicLinkStatusException
+import id.passage.android.exceptions.GetMagicLinkStatusNotFoundException
+import id.passage.android.exceptions.HostedAuthorizationError
+import id.passage.android.exceptions.HostedLogoutException
+import id.passage.android.exceptions.LoginException
+import id.passage.android.exceptions.LoginNoExistingUserException
+import id.passage.android.exceptions.LoginNoFallbackException
+import id.passage.android.exceptions.LoginWithPasskeyException
+import id.passage.android.exceptions.MagicLinkActivateException
+import id.passage.android.exceptions.NewLoginMagicLinkException
+import id.passage.android.exceptions.NewLoginOneTimePasscodeException
+import id.passage.android.exceptions.NewRegisterMagicLinkException
+import id.passage.android.exceptions.NewRegisterOneTimePasscodeException
+import id.passage.android.exceptions.OneTimePasscodeActivateException
+import id.passage.android.exceptions.PassageTokenException
+import id.passage.android.exceptions.RegisterException
+import id.passage.android.exceptions.RegisterNoFallbackException
+import id.passage.android.exceptions.RegisterPublicDisabledException
+import id.passage.android.exceptions.RegisterUserExistsException
+import id.passage.android.exceptions.RegisterWithPasskeyException
 import id.passage.android.model.ActivateMagicLinkRequest
 import id.passage.android.model.ActivateOneTimePasscodeRequest
 import id.passage.android.model.AuthenticatorAttachment
@@ -688,18 +709,16 @@ public final class Passage(
      * This method completes the hosted authentication process by exchanging the provided authorization code for Passage tokens.
      *
      * @param code The code returned from app link redirect to your activity.
-     * @param clientSecret You hosted app's client secret, found in Passage Console's OIDC Settings.
      * @param state The state returned from app link redirect to your activity.
      * @throws HostedAuthorizationError
      */
 
     public suspend fun hostedAuthFinish(
         code: String,
-        clientSecret: String,
         state: String,
     ): Pair<PassageAuthResult, String> {
         try {
-            val finishHostedAuthResult = PassageHosted.finishHostedAuth(code, clientSecret, state)
+            val finishHostedAuthResult = PassageHosted.finishHostedAuth(code, state)
             finishHostedAuthResult.let { (authResult, idToken) ->
                 handleAuthResult(authResult)
                 handleIdToken(idToken)

--- a/passage/src/main/java/id/passage/android/PassageHosted.kt
+++ b/passage/src/main/java/id/passage/android/PassageHosted.kt
@@ -31,9 +31,8 @@ internal class PassageHosted {
             packageName = activity.packageName
             val redirectUri = "$basePathOIDC/android/$packageName/callback"
             state = Utils.getRandomString()
-            val randomString = Utils.getRandomString()
             verifier = Utils.getRandomString()
-            val codeChallenge = Utils.sha256Hash(randomString)
+            val codeChallenge = Utils.sha256Hash(verifier)
             val newParams =
                 listOf(
                     "client_id" to appId,
@@ -53,7 +52,6 @@ internal class PassageHosted {
 
         internal suspend fun finishHostedAuth(
             code: String,
-            clientSecret: String,
             state: String,
         ): Pair<AuthResult, String> {
             val redirectUri = "$basePathOIDC/android/$packageName/callback"
@@ -76,8 +74,7 @@ internal class PassageHosted {
                     "grant_type" to "authorization_code",
                     "code" to code,
                     "client_id" to Passage.appId,
-                    "verifier" to verifier,
-                    "client_secret" to clientSecret,
+                    "code_verifier" to verifier,
                     "redirect_uri" to redirectUri,
                 ).joinToString("&") { (key, value) ->
                     "$key=${URLEncoder.encode(value, "UTF-8")}"
@@ -123,7 +120,7 @@ internal class PassageHosted {
             idToken: String,
         ) {
             val redirectUri = "$basePathOIDC/android/$packageName/logout"
-            verifier = Utils.getRandomString()
+            state = Utils.getRandomString()
             val url =
                 Uri
                     .parse("$basePathOIDC/logout")
@@ -131,7 +128,7 @@ internal class PassageHosted {
                     .appendQueryParameter("id_token_hint", idToken)
                     .appendQueryParameter("client_id", appId)
                     .appendQueryParameter("post_logout_redirect_uri", redirectUri)
-                    .appendQueryParameter("state", verifier)
+                    .appendQueryParameter("state", state)
                     .build()
 
             val customTabsIntent = CustomTabsIntent.Builder().build()


### PR DESCRIPTION
Enhanced the security of authorization code grant flow using [PCKE](https://blog.postman.com/what-is-pkce/).

Developers don't need to pass the client secret and can simply call:

```java
passage.hostedAuthStart()
// Intercept authorization code and state from redirect, then:
passage.hostedAuthFinish(authCode, state)
```